### PR TITLE
Expose uploaded images for frontend display

### DIFF
--- a/src/main/java/com/chatop/config/SecurityConfig.java
+++ b/src/main/java/com/chatop/config/SecurityConfig.java
@@ -44,6 +44,8 @@ public class SecurityConfig {
                 .requestMatchers("/api/auth/login", "/api/auth/register").permitAll()
                 // Optionnel : autoriser la documentation Swagger
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                // Autorise l'accès public aux images uploadées
+                .requestMatchers( "/uploads/**" ).permitAll()
                 // Toutes les autres nécessitent un token valide
                 .anyRequest().authenticated()
             )

--- a/src/main/java/com/chatop/config/WebConfig.java
+++ b/src/main/java/com/chatop/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.chatop.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Expose le répertoire local des images uploadées via une URL publique.
+ */
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations("file:uploads/");
+    }
+}

--- a/src/main/java/com/chatop/service/RentalService.java
+++ b/src/main/java/com/chatop/service/RentalService.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -130,7 +131,12 @@ public class RentalService {
             Files.createDirectories(uploadDir); // Crée le dossier s'il n'existe pas
             Path filePath = uploadDir.resolve(fileName);
             Files.copy(picture.getInputStream(), filePath, StandardCopyOption.REPLACE_EXISTING);
-            return filePath.toString();
+
+            // Retourne une URL absolue accessible publiquement
+            return ServletUriComponentsBuilder.fromCurrentContextPath()
+                    .path("/uploads/")
+                    .path(fileName)
+                    .toUriString();
         } catch (IOException e) {
             throw new RuntimeException("Could not store picture", e);
         }


### PR DESCRIPTION
1. Serve the uploads directory through Spring MVC to make stored pictures reachable at /uploads/**.
2. Adjust rental picture storage to return absolute URLs, allowing Angular to render the images.